### PR TITLE
choose_equal_split refactorization + alternative with pandas/sklearn

### DIFF
--- a/choose_equal_split.py
+++ b/choose_equal_split.py
@@ -1,32 +1,24 @@
-file = open('trainingData.csv')
+"""split data into training and validation sets"""
+import csv
 
-data = file.readlines()[1:]
-langs = set()
-for line in data:
-    filepath, language = line.split(',')
-    filepath = filepath.strip()
-    language = language.strip()
-    langs.add(language)
+with open('trainingData.csv', 'rb') as csvfile:
+    next(csvfile) #skip headers
+    data = list(csv.reader(csvfile, delimiter=','))
 
-langs = sorted(langs)
-ID = {}
-for id, lang in enumerate(langs):
-    ID[lang] = id
-file.close()
+    #Map every language to an ID
+    langs = set([language.strip() for _,language in data])
+    ID = {lang: i for i,lang in enumerate(sorted(langs))}
 
-train = open('trainEqual.csv', 'w')
-val = open('valEqaul.csv', 'w')
-cnt = [0 for x in range(176)]
-for line in data:
-    filepath, language = line.split(',')
-    filepath = filepath.strip()
-    language = language.strip()
-    id = ID[language]
-    if (cnt[id] < 306):
-        train.write(filepath[:-4] + ',' + str(ID[language]) + '\n')
-    else:
-        val.write(filepath[:-4] + ',' + str(ID[language]) + '\n')
-    cnt[id] += 1
-    
-train.close()
-val.close()
+    #Write first 306 items to training set and the rest to validation set
+    cnt = [0 for _ in range(len(langs))]
+    with open('trainEqual.csv', 'w') as train:
+        with open('valEqaul.csv', 'w') as val:
+            for line in data:
+                filepath, language = map(str.strip, line)
+                id_lang = ID[language]
+
+                if (cnt[id_lang] < 306):
+                    train.write(filepath[:-4] + ',' + str(id_lang) + '\n')
+                else:
+                    val.write(filepath[:-4] + ',' + str(id_lang) + '\n')
+                cnt[id_lang] += 1

--- a/choose_equal_split_pandas.py
+++ b/choose_equal_split_pandas.py
@@ -1,0 +1,20 @@
+"""split data into training and validation sets with pandas/scikit-learn"""
+import pandas as pd
+from sklearn.preprocessing import LabelEncoder
+
+#Read csv and drop file extension
+df = pd.read_csv('trainingData.csv', names=['filename','lang'],
+                 converters={'filename': lambda f: f[:-4]}, header=0)
+
+#LabelEncoding the languages (LabelEncoder sorts values internally)
+df['lang'] = LabelEncoder().fit_transform(df['lang'])
+
+#Get first 306 rows for each lang
+first_N_rows_per_lang_idx = df.groupby('lang').head(306).index
+train = df.iloc[first_N_rows_per_lang_idx]
+val   = df.iloc[~df.index.isin(first_N_rows_per_lang_idx)]
+
+#Write to csv
+to_csv_args = dict(sep=',', index=False, header=False)
+train.to_csv('trainEqual_pandas.csv',**to_csv_args )
+val.to_csv('valEqaul_pandas.csv', **to_csv_args)


### PR DESCRIPTION
Hi

Thank you for sharing your code, it is really helping me understand how to play with RNN and CNN.

When working on the fork, I had the opportunity to improve the readability of the choose_equal_split script:
- first using only Python. One commit updates the original version.
- then using pandas/scikitlearn. Another commit with a new file even more readable (in my opinion). I created another file in case one would not want to add these dependencies. 

The outputs (csv files) are the same as the original version (your master branch). 
I tested both versions by comparing every csv files with the original ones (see gist below)

The CSV used as inputs is of the form:

> Sample Filename,Language
> 000kouqjfnk.mp3,Hmong Daw
> 000w3fewuqj.mp3,Tektiteko
> 000ylhu4sxl.mp3,Teribe
> 0014x3zvjrl.mp3,Chipaya

```
import pandas as pd
train_original = pd.read_csv("trainEqual.csv")
train_pandas = pd.read_csv("trainEqual_pandas.csv")
val_original = pd.read_csv("valEqaul.csv")
val_pandas = pd.read_csv("valEqaul_pandas.csv")

train_original.equals(train_pandas) and val_original.equals(val_pandas) #True
```

Any feedback is welcome.

Cheers,
x0s
